### PR TITLE
Pass in the backup type to the controller

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -30,6 +30,8 @@ type Config struct {
 	ExcludeReplica string
 	LogLevel       string
 	DockerImageURI string
+	BackupType     string
+	Hostname       string
 }
 
 // realMongoClient wraps the MongoDB Database struct to work around the fact that mongo.SingleResult has no exported fields we can mock.
@@ -77,6 +79,21 @@ func NewConfig() (Config, error) {
 		return conf, fmt.Errorf("docker image URI - DOCKER_IMAGE_URI - has not been set")
 	}
 	conf.DockerImageURI = dockerImageURI
+
+	// What type of backup to trigger
+	backupType := os.Getenv("BACKUP_TYPE")
+	if backupType != "hourly" && backupType != "daily" {
+		return conf, fmt.Errorf("BACKUP_TYPE must be 'hourly' or 'daily'")
+	}
+	conf.BackupType = backupType
+
+	// Get the hostname so we annotate the created jobs with the owner
+	hostname := os.Getenv("HOSTNAME")
+	if hostname != "" {
+		conf.Hostname = hostname
+	} else {
+		conf.Hostname = "unknown"
+	}
 
 	// MongoDB Client
 	mongoDBc, err := mongoDBClient()

--- a/internal/service/k8s_test.go
+++ b/internal/service/k8s_test.go
@@ -29,8 +29,8 @@ func Test_createJob(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, job)
 	assert.Equal(t, job.Namespace, namespace)
-	assert.Contains(t, job.Annotations, "karpenter.sh/do-not-disrupt")
-	
+	assert.Contains(t, job.Spec.Template.Annotations, "karpenter.sh/do-not-disrupt")
+
 	expressions := job.Spec.Template.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions
 	var foundAZAffinity bool
 	var foundNodePoolAffinity bool

--- a/internal/service/mongoDB_test.go
+++ b/internal/service/mongoDB_test.go
@@ -40,19 +40,19 @@ func Test_mongoDBReadReplicaToTarget(t *testing.T) {
 	}{
 		{
 			name: "GoodWithExcludeReplica", ok: 1, members: []member{
-				{Name: "mongodb-0.mongodb.database.svc.cluster.local", Role: "PRIMARY"},
-				{Name: "mongodb-1.mongodb.database.svc.cluster.local", Role: "SECONDARY"},
-				{Name: "mongodb-2.mongodb.database.svc.cluster.local", Role: "SECONDARY"}},
+			{Name: "mongodb-0.mongodb.database.svc.cluster.local", Role: "PRIMARY"},
+			{Name: "mongodb-1.mongodb.database.svc.cluster.local", Role: "SECONDARY"},
+			{Name: "mongodb-2.mongodb.database.svc.cluster.local", Role: "SECONDARY"}},
 			excludeReplica: "mongodb-1.mongodb.database.svc.cluster.local",
 			expectedTarget: "mongodb-2.mongodb.database.svc.cluster.local",
 			expectedError:  false,
 		},
 		{
 			name: "GoodWithNoExcludeReplica", ok: 1, members: []member{
-				{Name: "mongodb-0.mongodb.database.svc.cluster.local", Role: "PRIMARY"},
-				{Name: "mongodb-1.mongodb.database.svc.cluster.local", Role: "SECONDARY"},
-				{Name: "mongodb-2.mongodb.database.svc.cluster.local", Role: "SECONDARY"}},
-			expectedTarget: "mongodb-1.mongodb.database.svc.cluster.local",
+			{Name: "mongodb-0.mongodb.database.svc.cluster.local", Role: "SECONDARY"},
+			{Name: "mongodb-1.mongodb.database.svc.cluster.local", Role: "PRIMARY"},
+			{Name: "mongodb-2.mongodb.database.svc.cluster.local", Role: "SECONDARY"}},
+			expectedTarget: "mongodb-0.mongodb.database.svc.cluster.local",
 			expectedError:  false,
 		},
 		{
@@ -67,18 +67,18 @@ func Test_mongoDBReadReplicaToTarget(t *testing.T) {
 		},
 		{
 			name: "DebugLogging", ok: 1, members: []member{
-				{Name: "mongodb-0.mongodb.database.svc.cluster.local", Role: "PRIMARY"},
-				{Name: "mongodb-1.mongodb.database.svc.cluster.local", Role: "SECONDARY"},
-				{Name: "mongodb-2.mongodb.database.svc.cluster.local", Role: "SECONDARY"}},
-			expectedTarget: "mongodb-1.mongodb.database.svc.cluster.local",
+			{Name: "mongodb-0.mongodb.database.svc.cluster.local", Role: "SECONDARY"},
+			{Name: "mongodb-1.mongodb.database.svc.cluster.local", Role: "SECONDARY"},
+			{Name: "mongodb-2.mongodb.database.svc.cluster.local", Role: "PRIMARY"}},
+			expectedTarget: "mongodb-0.mongodb.database.svc.cluster.local",
 			expectedError:  false,
 			logLevel:       "debug",
 		},
 		{
 			name: "FailedDecode", ok: 1, members: []member{
-				{Name: "mongodb-0.mongodb.database.svc.cluster.local", Role: "PRIMARY"},
-				{Name: "mongodb-1.mongodb.database.svc.cluster.local", Role: "SECONDARY"},
-				{Name: "mongodb-2.mongodb.database.svc.cluster.local", Role: "SECONDARY"}},
+			{Name: "mongodb-0.mongodb.database.svc.cluster.local", Role: "PRIMARY"},
+			{Name: "mongodb-1.mongodb.database.svc.cluster.local", Role: "SECONDARY"},
+			{Name: "mongodb-2.mongodb.database.svc.cluster.local", Role: "SECONDARY"}},
 			expectedTarget: "",
 			expectedError:  true,
 		},

--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,7 @@ export MONGODB_USERNAME=<username>                                          # Us
 export MONGODB_PASSWORD=<password>                                          # Password for connecting to the DB
 export DOCKER_IMAGE_URI=<repo>:<tag>                                        # Docker image that is run in the provisioned K8s job. Should perform the actual backup e.g. mongodump
 export RUNNING_LOCALLY=true                                                 # Use a local kubeconfig rather than in-cluster config for the K8s client
+export BACKUP_TYPE=hourly                                                   # The backup type to pass to the provisioned backup script. Must be 'hourly' or 'daily'
 
 # Port forward to any of the MongoDB pods in the replica set
 kubectl -n database port-forward sts/mongodb 27017:27017 &


### PR DESCRIPTION
Pass in BACKUP_TYPE as an envar to the controller so we can pass it as a parameter to the backup job which is provisioned into the target namespace. This allows us to create a simple backup policy for retention and storage tiers etc.